### PR TITLE
Fixing Readme clone snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Documentation is available at https://docs.digitalocean.com/products/functions.
 
 ```bash
 # clone this repo
-git clone git@github.com:digitalocean/sample-functions-golang-presigned-url.git
+git clone https://github.com/digitalocean/sample-functions-golang-presigned-url
 ```
 
 ```


### PR DESCRIPTION
Using SSH while cloning like previously doesn't work for everyone. Using HTTP cloning prevents the git@github.com: Permission denied (publickey) error.